### PR TITLE
feat: added "excludeDisabledDays" prop for range picker

### DIFF
--- a/src/contexts/SelectRange/utils/addToRange.test.ts
+++ b/src/contexts/SelectRange/utils/addToRange.test.ts
@@ -48,6 +48,15 @@ describe('when no "to" is the range', () => {
       expect(result).toEqual({ from: range.from, to: day });
     });
   });
+  describe('and the day is the same as the "from" day but with a min provided', () => {
+    let result: DateRange | undefined;
+    beforeAll(() => {
+      result = addToRange(day, range, 2);
+    });
+    test('should set the day as the "to" date', () => {
+      expect(result).toEqual(undefined);
+    });
+  });
 });
 
 describe('when "from", "to" and "day" are the same', () => {

--- a/src/contexts/SelectRange/utils/addToRange.ts
+++ b/src/contexts/SelectRange/utils/addToRange.ts
@@ -10,7 +10,8 @@ import { DateRange } from 'types/Matchers';
  */
 export function addToRange(
   day: Date,
-  range?: DateRange
+  range?: DateRange,
+  min?: number
 ): DateRange | undefined {
   const { from, to } = range || {};
   if (from && to) {
@@ -37,6 +38,9 @@ export function addToRange(
   if (from) {
     if (isBefore(day, from)) {
       return { from: day, to: from };
+    }
+    if (min && min > 1 && isSameDay(from, day)) {
+      return undefined;
     }
     return { from, to: day };
   }

--- a/src/contexts/SelectRange/utils/findDisabledDays.test.ts
+++ b/src/contexts/SelectRange/utils/findDisabledDays.test.ts
@@ -1,0 +1,81 @@
+import { addDays } from 'date-fns';
+
+import { freezeBeforeAll } from 'test/utils';
+
+import { findDisabledDays } from './findDisabledDays';
+
+const today = new Date(2021, 11);
+freezeBeforeAll(today);
+
+type Result = { after: Date | undefined; before: Date | undefined } | undefined;
+
+const disabledDays = [
+  addDays(today, 2),
+  [addDays(today, 6), addDays(today, 20)],
+  { from: addDays(today, 15), to: addDays(today, 17) }
+];
+
+describe('when a day is selected between two disabled days - test 1', () => {
+  let result: Result;
+  beforeAll(() => {
+    result = findDisabledDays(addDays(today, 4), disabledDays);
+  });
+  test('should return after and before', () => {
+    expect(result).toEqual({
+      after: addDays(today, 6),
+      before: addDays(today, 2)
+    });
+  });
+});
+
+describe('when a day is selected between two disabled days - test 2', () => {
+  let result: Result;
+  beforeAll(() => {
+    result = findDisabledDays(addDays(today, 19), disabledDays);
+  });
+  test('should return after and before', () => {
+    expect(result).toEqual({
+      after: addDays(today, 20),
+      before: addDays(today, 18)
+    });
+  });
+});
+
+describe('when a day is selected between two disabled days - test 3', () => {
+  let result: Result;
+  beforeAll(() => {
+    result = findDisabledDays(addDays(today, 10), disabledDays);
+  });
+  test('should return after and before', () => {
+    expect(result).toEqual({
+      after: addDays(today, 14),
+      before: addDays(today, 6)
+    });
+  });
+});
+
+describe('when a day is selected before a disabled day', () => {
+  let result: Result;
+  beforeAll(() => {
+    result = findDisabledDays(today, disabledDays);
+  });
+  test('should return after and before', () => {
+    expect(result).toEqual({
+      after: addDays(today, 2),
+      before: undefined
+    });
+  });
+});
+
+describe('when a day is selected after a disabled day', () => {
+  let result: Result;
+  beforeAll(() => {
+    result = findDisabledDays(addDays(today, 22), disabledDays);
+  });
+  test('should return after and before', () => {
+    expect(result).toEqual({
+      after: undefined,
+      before: addDays(today, 20)
+    });
+  });
+});

--- a/src/contexts/SelectRange/utils/findDisabledDays.ts
+++ b/src/contexts/SelectRange/utils/findDisabledDays.ts
@@ -1,0 +1,145 @@
+import {
+  addDays,
+  compareAsc,
+  compareDesc,
+  isAfter,
+  isBefore,
+  isDate,
+  nextDay,
+  previousDay,
+  subDays
+} from 'date-fns';
+
+import { DayPickerRangeProps } from 'types/DayPickerRange';
+import {
+  isDateAfterType,
+  isDateBeforeType,
+  isDateInterval,
+  isDateRange,
+  isDayOfWeekType,
+  Matcher
+} from 'types/Matchers';
+
+/** Returns true if `value` is a Date type. */
+function isDateType(value: unknown): value is Date {
+  return isDate(value);
+}
+
+/** Returns true if `value` is an array of valid dates. */
+function isArrayOfDates(value: unknown): value is Date[] {
+  return Array.isArray(value) && value.every(isDate);
+}
+
+const closestDisabledDate = (
+  date: Date,
+  matcher: Matcher,
+  descending?: boolean
+) => {
+  const checker = descending ? isAfter : isBefore;
+
+  if (typeof matcher === 'boolean') {
+    return undefined;
+  }
+
+  if (isDateType(matcher) && checker(date, matcher)) {
+    return matcher;
+  }
+
+  if (isArrayOfDates(matcher)) {
+    return matcher.reduce((acc: Date | undefined, value: Date) => {
+      if (acc) {
+        return checker(value, acc) && checker(date, value) ? value : acc;
+      }
+      return checker(date, value) ? value : undefined;
+    }, undefined);
+  }
+
+  if (isDateRange(matcher)) {
+    if (!descending && matcher.from && checker(date, matcher.from)) {
+      return subDays(matcher.from, 1);
+    }
+    if (descending && matcher.to && checker(date, matcher.to)) {
+      return addDays(matcher.to, 1);
+    }
+    return undefined;
+  }
+
+  if (isDayOfWeekType(matcher)) {
+    const sorter = descending ? compareDesc : compareAsc;
+    const getDayOfWeek = descending ? previousDay : nextDay;
+    const value = matcher.dayOfWeek
+      .map((d) => getDayOfWeek(date, d as Day))
+      .sort(sorter)[0];
+    return value;
+  }
+
+  if (isDateInterval(matcher) && checker(date, matcher.after)) {
+    if (!descending && checker(date, matcher.after)) {
+      return matcher.after;
+    }
+
+    if (descending && checker(date, matcher.before)) {
+      return matcher.before;
+    }
+
+    return undefined;
+  }
+
+  if (isDateAfterType(matcher) && !descending && checker(date, matcher.after)) {
+    return matcher.after;
+  }
+
+  if (
+    isDateBeforeType(matcher) &&
+    descending &&
+    checker(date, matcher.before)
+  ) {
+    return matcher.before;
+  }
+
+  return undefined;
+};
+
+export const findDisabledDays = (
+  date: Date,
+  disabled: DayPickerRangeProps['disabled']
+): { after: Date | undefined; before: Date | undefined } | undefined => {
+  if (Array.isArray(disabled)) {
+    return {
+      after: (disabled as Matcher[]).reduce(
+        (acc: Date | undefined, value: Matcher) => {
+          const nextValue = closestDisabledDate(date, value);
+          if (nextValue) {
+            if (acc && isBefore(nextValue, acc)) {
+              return nextValue;
+            }
+            return acc || nextValue;
+          }
+          return acc;
+        },
+        undefined
+      ),
+      before: (disabled as Matcher[]).reduce(
+        (acc: Date | undefined, value: Matcher) => {
+          const nextValue = closestDisabledDate(date, value, true);
+          if (nextValue) {
+            if (acc && isAfter(nextValue, acc)) {
+              return nextValue;
+            }
+            return acc || nextValue;
+          }
+          return acc;
+        },
+        undefined
+      )
+    };
+  }
+  if (disabled !== undefined) {
+    return {
+      after: closestDisabledDate(date, disabled),
+      before: closestDisabledDate(date, disabled, true)
+    };
+  }
+
+  return undefined;
+};

--- a/src/contexts/SelectRange/utils/index.ts
+++ b/src/contexts/SelectRange/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './addToRange';
+export * from './findDisabledDays';

--- a/src/types/DayPickerRange.ts
+++ b/src/types/DayPickerRange.ts
@@ -17,6 +17,8 @@ export interface DayPickerRangeProps extends DayPickerBase {
   min?: number;
   /** The maximum amount of days that can be selected. */
   max?: number;
+  /** Exclude disabled date from the range */
+  excludeDisabledDays?: boolean;
 }
 
 /** Returns true when the props are of type {@link DayPickerRangeProps}. */

--- a/website/docs/basics/selecting-days.md
+++ b/website/docs/basics/selecting-days.md
@@ -56,6 +56,14 @@ Use the `min` and `max` props to limit the amount of days in the range.
 range-min-max
 ```
 
+### Excluding disabled days in range
+
+Use `excludeDisabledDays` to disable selecting a disabled day in the range.
+
+```include-example
+exclude-disabled-days
+```
+
 ## Custom Selections
 
 If the built-in selection modes are not enough for your app’s requirements, you can control the selection behavior using `onDayClick`.

--- a/website/examples/exclude-disabled-days.tsx
+++ b/website/examples/exclude-disabled-days.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+
+import { addDays, format } from 'date-fns';
+import { DateRange, DayPicker } from 'react-day-picker';
+
+const defaultMonth = new Date(2022, 8);
+
+export default function App() {
+  const [range, setRange] = useState<DateRange | undefined>();
+
+  const disabledDays = [
+    addDays(defaultMonth, 6),
+    addDays(defaultMonth, 20),
+    { dayOfWeek: [0] },
+    { from: addDays(defaultMonth, 12), to: addDays(defaultMonth, 13) }
+  ];
+
+  let footer = <p>Please pick the first day.</p>;
+  if (range?.from) {
+    if (!range.to) {
+      footer = <p>{format(range.from, 'PPP')}</p>;
+    } else if (range.to) {
+      footer = (
+        <p>
+          {format(range.from, 'PPP')}–{format(range.to, 'PPP')}
+        </p>
+      );
+    }
+  }
+
+  return (
+    <DayPicker
+      defaultMonth={defaultMonth}
+      mode="range"
+      min={2}
+      disabled={disabledDays}
+      excludeDisabledDays
+      selected={range}
+      onSelect={setRange}
+      footer={footer}
+    />
+  );
+}

--- a/website/test-integration/examples/range-min-max.test.tsx
+++ b/website/test-integration/examples/range-min-max.test.tsx
@@ -27,7 +27,6 @@ describe('when the first day is clicked', () => {
   });
   test('the days below the min value should be disabled', () => {
     expect(getDayButton(setDate(today, 13))).toBeDisabled();
-    expect(getDayButton(setDate(today, 14))).toBeDisabled();
     expect(getDayButton(setDate(today, 15))).toBeDisabled();
   });
   test('the days between max and min should be enabled', () => {


### PR DESCRIPTION
### Context

I'm planning to use react-day-picker for a booking website and typically I would use the range picker. Days that are already booked would appear as disabled but the current package let the user pick a range with potentially disabled days inside.
In that particular use-case, it doesn't work as a booking can't overlap another one. 

<img width="334" alt="Screenshot 2023-12-21 at 20 29 30" src="https://github.com/gpbl/react-day-picker/assets/23291640/4ada7596-bf46-4722-9937-40c49e7e91df"> <img width="323" alt="Screenshot 2023-12-21 at 20 29 56" src="https://github.com/gpbl/react-day-picker/assets/23291640/dbe90452-dc90-4566-94c3-55a1c651e522">



### Analysis

Current code only disables dates for clicking on it, so when a user selects a range, the `from` can be before a disabled date and the `to` after, hence selecting a disabled date. In a case of a booking website, that would mean someone could double book.

### Solution

My solution is to pass a boolean `excludeDisabledDays` as prop and if true, the modifiers.disabled will be updated with the enclosing disabled dates. Hence if the user selects a date before a disabled date, then all the dates after that disabled date will be also disabled. The function `findDisabledDays` looks for the closest disabled dates after and before the selected date and that result is used to update the disabled dates accordingly. 
The function `addToRange` had to be updated as with a `min` provided, the user could have ended up in the situation where no other dates could be selected. Clicking again on the selected date will now clear the range.
<img width="297" alt="Screenshot 2023-12-21 at 20 31 30" src="https://github.com/gpbl/react-day-picker/assets/23291640/0a612495-1f5d-418e-9c7c-cc20ba00254c"> <img width="307" alt="Screenshot 2023-12-21 at 20 31 44" src="https://github.com/gpbl/react-day-picker/assets/23291640/35767131-9c8f-4277-9281-df1bbefa4954">

